### PR TITLE
Update buildpack now that JQ is in the base image

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # heroku-buildpack-jq
 
+> [!WARNING]
+> JQ is [now installed](https://devcenter.heroku.com/changelog-items/2893) in both Heroku's build and run images.
+> As such, this buildpack is no longer required to use JQ on Heroku.
+
 Use [Heroku multi-buildpacks](https://devcenter.heroku.com/articles/using-multiple-buildpacks-for-an-app).
 
 For example:

--- a/bin/compile
+++ b/bin/compile
@@ -8,16 +8,28 @@ CACHE_DIR=$2
 PROFILE_PATH="$BUILD_DIR/.profile.d/jq.sh"
 mkdir -p $(dirname $PROFILE_PATH)
 
-function set-default-env (){
-  echo "export $1=\$$1:/app/vendor/jq/$2" >> $PROFILE_PATH
+function set-env (){
+  # We use the conditional parameter expansion form (eg `${FOO:+:$FOO}`) to avoid adding a redundant
+  # delimiter if the env var wasn't already set (which is often the case for LD_LIBRARY_PATH):
+  # https://stackoverflow.com/a/16296567
+  echo "export $1=/app/vendor/jq/$2\${$1:+:\$$1}" >> $PROFILE_PATH
 }
 
-set-default-env LD_LIBRARY_PATH "lib"
-set-default-env PATH "bin"
+set-env LD_LIBRARY_PATH "lib"
+set-env PATH "bin"
 
 indent() {
   sed -u 's/^/       /'
 }
 
 cd $BUILD_DIR
+
+if command -v jq > /dev/null; then
+    echo " !     jq is already installed! It has been added to both Heroku's build and run images as of:" >&2
+    echo " !     https://devcenter.heroku.com/changelog-items/2893" >&2
+    echo " !     " >&2
+    echo " !     As such, this buildpack is no longer required, and can be removed using:" >&2
+    echo " !     $ heroku buildpacks:remove https://github.com/chrismytton/heroku-buildpack-jq.git" >&2
+fi
+
 curl -fsSL https://github.com/chrismytton/heroku-buildpack-jq/raw/master/jq-1.5-heroku.tar.gz | tar xzf - | indent


### PR DESCRIPTION
JQ has now been added to Heroku's run time image as of:
https://devcenter.heroku.com/changelog-items/2893
https://github.com/heroku/base-images/pull/308

This now means it's present both at run time and build time (previously it was only available at build time). See:
https://devcenter.heroku.com/articles/stack-packages

As such, the buildpack's handling of env vars needs fixing to put the buildpack jq first on `PATH` instead of last, so that system jq doesn't end up being run against the vendored jq library, which otherwise causes errors like:

```
jq: symbol lookup error: jq: undefined symbol: jv_object_has
```

In addition, I've added a deprecation warning to let users know the buildpack is no longer required, and can be removed to speed up builds and reduce slug size.

I've left this as a warning only to minimise disruption to existing apps, and in case specific apps must use JQ 1.5 (rather than the newer versions in the base images), and so still want to use the buildpack.

Fixes #3.