### PR TITLE
Turn the deprecation warning into an error

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -25,11 +25,17 @@ indent() {
 cd $BUILD_DIR
 
 if command -v jq > /dev/null; then
-    echo " !     jq is already installed! It has been added to both Heroku's build and run images as of:" >&2
+    echo " !     Error: jq is already installed! It has been added to both Heroku's build and run images as of:" >&2
     echo " !     https://devcenter.heroku.com/changelog-items/2893" >&2
     echo " !     " >&2
-    echo " !     As such, this buildpack is no longer required, and can be removed using:" >&2
+    echo " !     As such, this buildpack is no longer required, and must be removed using:" >&2
+    echo " !     $ heroku buildpacks:remove <buildpack URL>" >&2
+    echo " !     " >&2
+    echo " !     For example:" >&2
     echo " !     $ heroku buildpacks:remove https://github.com/chrismytton/heroku-buildpack-jq.git" >&2
+    echo " !     (Run 'heroku buildpacks' to see the exact buildpack URL being used)" >&2
+    echo >&2
+    exit 1
 fi
 
 curl -fsSL https://github.com/chrismytton/heroku-buildpack-jq/raw/master/jq-1.5-heroku.tar.gz | tar xzf - | indent


### PR DESCRIPTION
Now that a year has passed since the buildpack's deprecation:
https://github.com/chrismytton/heroku-buildpack-jq/pull/4